### PR TITLE
Allow daemon to remain active in background: do not restart unless asked for

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -8,7 +8,7 @@ import (
 )
 
 func NewBrowser(url string) Runnable {
-	return func(kill chan struct{}) (chan bool, chan struct{}) {
+	return func(kill chan struct{}, quit chan struct{}) (chan bool, chan struct{}, bool) {
 		command := fmt.Sprintf("google-chrome \"%s\"", url)
 
 		cmd := &Cmd{
@@ -20,7 +20,7 @@ func NewBrowser(url string) Runnable {
 
 		go cmd.RunBrowser()
 
-		return cmd.done, cmd.dead
+		return cmd.done, cmd.dead, true
 	}
 }
 

--- a/browser_darwin.go
+++ b/browser_darwin.go
@@ -42,7 +42,7 @@ var chromeApplescript = `
 `
 
 func NewBrowser(url string) Runnable {
-	return func(kill chan struct{}) (chan bool, chan struct{}) {
+	return func(kill chan struct{}, quit chan struct{}) (chan bool, chan struct{}, bool) {
 		cmd := &Cmd{
 			Cmd:  exec.Command("osascript"),
 			Name: url,
@@ -52,7 +52,7 @@ func NewBrowser(url string) Runnable {
 
 		go cmd.RunBrowser(url)
 
-		return cmd.done, cmd.dead
+		return cmd.done, cmd.dead, true
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func runChain(watcher *Watcher, quit chan struct{}) {
 			}
 		}()
 
-		var globallyKnownPrograms map[chan struct{}]bool
+		var globallyKnownPrograms map[chan struct{}]bool = make(map[chan struct{}]bool)
 		var globalWg sync.WaitGroup
 
 	RunLoop:
@@ -163,6 +163,7 @@ func runChain(watcher *Watcher, quit chan struct{}) {
 				}()
 			} else {
 				if _, ok := globallyKnownPrograms[dead]; !ok {
+					globallyKnownPrograms[dead] = true
 					globalWg.Add(1)
 					go func() {
 						<-dead


### PR DESCRIPTION
I am trying out ReactJS, and I found out that this is basically operation I would like to do:

```
wago -dir=. -ignore=build -cmd='babel src --out-dir build' -daemon='livereload -server=":8080" -serve="." . build' -daemonRestart=false
```

So, server needs to be the livereload server (I can't use internal wago server unfortunately for this) and I want babel to convert all JSX files I have in src into build. But I don't want it to restart livereload server, since it beats the purpose of it: if it gets restarted livereload server <->browser connection is lost.

Because of that, I decided to add a new parameter to wago: `daemonRestart` that tells wago _not_ to restart daemon when single loop of chain has been executed: only wait for termination of that daemon program (as before) or await Ctrl+C to send quit message to the daemon.

That said: things work but I am not pleased with 2 things:
- I didn't have time to do the test this weekend (very limited time I gave myself for this patch) 
- at the same time I think I have been stretching the idea to far of multiple returns from the Runnables - I would suggest already refactoring this 3-tuple into a response object.
